### PR TITLE
Add module to notify external API on new user registrations

### DIFF
--- a/modules/RegistrationApi/Listeners/SendUserToApi.php
+++ b/modules/RegistrationApi/Listeners/SendUserToApi.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Modules\RegistrationApi\Listeners;
+
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class SendUserToApi
+{
+    public function handle(Registered $event): void
+    {
+        $user = $event->user;
+
+        $baseUrl  = config('registration_api.base_url');
+        $token    = config('registration_api.token');
+        $endpoint = config('registration_api.endpoint', '/api/send/template');
+        $template = config('registration_api.template');
+        $language = config('registration_api.language', 'en');
+        $header   = config('registration_api.header_image');
+        $payload0 = config('registration_api.button_payload_0');
+        $payload2 = config('registration_api.button_payload_2');
+
+        if (!$baseUrl || !$token || !$template) {
+            Log::warning('Registration API base URL, token, or template not configured.');
+            return;
+        }
+
+        $url = rtrim($baseUrl, '/') . '/' . ltrim($endpoint, '/');
+
+        $components = [];
+
+        if ($header) {
+            $components[] = [
+                'type' => 'header',
+                'parameters' => [[
+                    'type' => 'image',
+                    'image' => ['link' => $header],
+                ]],
+            ];
+        }
+
+        $bodyParams = [
+            ['type' => 'text', 'text' => $user->first_name ?? ''],
+            ['type' => 'text', 'text' => $user->last_name ?? ''],
+            ['type' => 'text', 'text' => $user->email ?? ''],
+        ];
+
+        $components[] = [
+            'type' => 'body',
+            'parameters' => $bodyParams,
+        ];
+
+        if ($payload0) {
+            $components[] = [
+                'type' => 'button',
+                'sub_type' => 'quick_reply',
+                'index' => '0',
+                'parameters' => [[
+                    'type' => 'payload',
+                    'payload' => $payload0,
+                ]],
+            ];
+        }
+
+        if ($payload2) {
+            $components[] = [
+                'type' => 'button',
+                'sub_type' => 'quick_reply',
+                'index' => '2',
+                'parameters' => [[
+                    'type' => 'payload',
+                    'payload' => $payload2,
+                ]],
+            ];
+        }
+
+        $payload = [
+            'phone' => $user->phone ?? null,
+            'template' => [
+                'name' => $template,
+                'language' => [
+                    'code' => $language,
+                ],
+                'components' => $components,
+            ],
+        ];
+
+        try {
+            Http::withHeaders([
+                'Authorization' => 'Bearer ' . $token,
+                'Content-Type' => 'application/json',
+            ])->post($url, $payload);
+        } catch (\Throwable $e) {
+            Log::error('Failed to send registration data to API: ' . $e->getMessage());
+        }
+    }
+}

--- a/modules/RegistrationApi/Providers/RegistrationApiServiceProvider.php
+++ b/modules/RegistrationApi/Providers/RegistrationApiServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Modules\RegistrationApi\Providers;
+
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\ServiceProvider;
+use Modules\RegistrationApi\Listeners\SendUserToApi;
+
+class RegistrationApiServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../config/registration_api.php', 'registration_api');
+    }
+
+    public function boot(): void
+    {
+        Event::listen(Registered::class, [SendUserToApi::class, 'handle']);
+    }
+}

--- a/modules/RegistrationApi/config/registration_api.php
+++ b/modules/RegistrationApi/config/registration_api.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'base_url' => env('REG_API_BASE_URL'),
+    'token' => env('REG_API_TOKEN'),
+    'endpoint' => env('REG_API_ENDPOINT', '/api/send/template'),
+    'template' => env('REG_API_TEMPLATE'),
+    'language' => env('REG_API_LANGUAGE', 'en'),
+    'header_image' => env('REG_API_HEADER_IMAGE'),
+    'button_payload_0' => env('REG_API_BUTTON_PAYLOAD_0'),
+    'button_payload_2' => env('REG_API_BUTTON_PAYLOAD_2'),
+];


### PR DESCRIPTION
## Summary
- move registration API configuration into module with env-driven settings
- post new user phone, first name, last name, and email using template components

## Testing
- `./vendor/bin/phpunit` *(fails: Test directory "/workspace/stage.whapier.com/tests/Unit" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b17edc48f88325bf94c7aeb6158622